### PR TITLE
feat: change event name to COSCUP x RubyConf Taiwan 2025

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -5,7 +5,7 @@ import { conference } from '#data/conference.js'
 <template>
   <footer id="footer">
     <section class="title">
-      <h1>COSCUP</h1>
+      <h1>COSCUP x RubyConf Taiwan 2025</h1>
       <h2>Conference for Open Source Coders, Users, and Promoters</h2>
     </section>
     <section class="contact">

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -3,7 +3,7 @@
 layout: home
 
 hero:
-  name: COSCUP 2025
+  name: COSCUP x RubyConf Taiwan 2025
   text: 社群大拜拜
   tagline: Conference for Open Source Coders, Users & Promoters
   actions:
@@ -30,7 +30,7 @@ features:
     linkText: More
   - title: Early Guide to Joining
     icon: 📣
-    details: Many people in the community are excited to find out how to participate in COSCUP 2025. We’ll share more updates soon, but here’s what we can share so far! You can join as a speaker, host a booth, organize a track, or become a sponsor...
+    details: Many people in the community are excited to find out how to participate in COSCUP x RubyConf Taiwan 2025. We’ll share more updates soon, but here’s what we can share so far! You can join as a speaker, host a booth, organize a track, or become a sponsor...
     link: https://blog.coscup.org/2025/01/early-guide-to-joining-coscup-2025.html
     linkText: More
 ---

--- a/content/en/sponsorship/index.md
+++ b/content/en/sponsorship/index.md
@@ -7,7 +7,7 @@ import SponsorTable from './parts/main.md'
 import AddonTable from './parts/addon.md'
 </script>
 
-# COSCUP Taiwan 2025 Sponsorship Program {style="text-align:center"}
+# COSCUP x RubyConf Taiwan 2025 Sponsorship Program {style="text-align:center"}
 
 ## Overview
 
@@ -117,7 +117,7 @@ To see our past conference photos, please visit : [COSCUP flickr album](https://
 }
 </style>
 
-## We wish all the sponsors in COSCUP Taiwan 2025 would
+## We wish all the sponsors in COSCUP x RubyConf Taiwan 2025 Taiwan 2025 would
 
 - Be inspired by new ideas and creativity.
 - Start new collaborative projects.

--- a/content/zh_tw/index.md
+++ b/content/zh_tw/index.md
@@ -3,7 +3,7 @@
 layout: home
 
 hero:
-  name: COSCUP 2025
+  name: COSCUP x RubyConf Taiwan 2025
   text: 社群大拜拜
   tagline: Conference for Open Source Coders, Users & Promoters
   actions:
@@ -30,7 +30,7 @@ features:
     linkText: 更多資訊
   - title: 早鳥加入指南
     icon: 📣
-    details: 社群中的許多人都對如何參與 COSCUP 2025 感到興奮！我們將很快分享更多更新，但目前可以透露一些資訊！您可以作為講者參與、設立攤位、組織議程，或成為贊助商。...
+    details: 社群中的許多人都對如何參與 COSCUP x RubyConf Taiwan 2025 感到興奮！我們將很快分享更多更新，但目前可以透露一些資訊！您可以作為講者參與、設立攤位、組織議程，或成為贊助商。...
     link: https://blog.coscup.org/2025/01/early-guide-to-joining-coscup-2025.html?m=1
     linkText: 更多資訊
 ---

--- a/content/zh_tw/sponsorship/index.md
+++ b/content/zh_tw/sponsorship/index.md
@@ -117,7 +117,7 @@ COSCUP (Conference for Open Source Coders, Users and Promoters ; 開源人年會
 }
 </style>
 
-## 我們期待所有的贊助單位在 COSCUP Taiwan 2025 都可以...
+## 我們期待所有的贊助單位在 COSCUP x RubyConf Taiwan 2025 都可以...
 
 - 激發新的想法、創意。
 - 獲得意想不到的合作計畫。

--- a/data/conference.ts
+++ b/data/conference.ts
@@ -14,14 +14,14 @@
  * Conference date: {{ start }} ~ {{ end }}
  */
 export const conference = {
-  title: 'COSCUP 2025',
+  title: 'COSCUP x RubyConf Taiwan 2025',
   description: 'Conference for Open Source Coders, Users, and Promoters is a free annual conference providing a platform to connect FLOSS folks across Asia since 2006. It\'s a major force of free software movement advocacy in Taiwan.',
   year: 2025,
   startDate: new Date('2025-08-09'),
   endDate: new Date('2025-08-10'),
   type: 'website',
-  url: 'https://coscup.org//2025/',
-  site_name: 'COSCUP 2025',
+  url: 'https://coscup.org/2025/',
+  site_name: 'COSCUP x RubyConf Taiwan 2025',
   og_image: '/2025/og-image.png',
   favicon: '/2025/favicon.svg',
 }


### PR DESCRIPTION
Implements changes requested in [this Mattermost thread](https://chat.coscup.org/coscup/pl/ihzqboerx3ro9cz14k8tbzgfuc).