### PR TITLE
refactor: remove custom Markdown syntax and configuration

### DIFF
--- a/.vitepress/config/index.ts
+++ b/.vitepress/config/index.ts
@@ -1,6 +1,4 @@
 import { resolve } from 'node:path'
-// @ts-expect-error - No type definitions available
-import markdownItContainer from 'markdown-it-container'
 import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 import IconsResolver from 'unplugin-icons/resolver'
 import Icons from 'unplugin-icons/vite'
@@ -16,22 +14,6 @@ import { zh_tw } from './zh_tw'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  markdown: {
-    config: (md) => {
-      md.use(markdownItContainer, 'div', {
-        render(tokens: Array<{ info: string }>, idx: number) {
-          const token = tokens[idx] as { info: string, nesting: number }
-          const klass = token.info.trim().slice(3).trim()
-          if (token.nesting === 1) {
-            return `<div class="${klass}">\n`
-          } else {
-            // 结束标签
-            return '</div>\n'
-          }
-        },
-      })
-    },
-  },
   vite: {
     resolve: {
       alias: {

--- a/content/en/sponsorship/index.md
+++ b/content/en/sponsorship/index.md
@@ -27,35 +27,25 @@ COSCUP 2024 Feedback Survey:
 
 <AddonTable />
 
-::: div addon-example
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/flag_dark.webp">
+  Logo on Stage Flag in Keynote Hall (co-branded with COSCUP)
+</div>
 
-![](/@/assets/images/sponsorships/flag_dark.webp)
-Logo on Stage Flag in Keynote Hall (co-branded with COSCUP)
-:::
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/promotion_dark.webp">
+  Promotion at the Snack Area (2 days)
+</div>
 
-::: div addon-example
-![](/@/assets/images/sponsorships/promotion_dark.webp)
-Promotion at the Snack Area (2 days)
-:::
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/lanyards_dark.webp">
+  Lanyards (Exclusive Sponsorship)
+</div>
 
-::: div addon-example
-![](/@/assets/images/sponsorships/lanyards_dark.webp)
-Lanyards (Exclusive Sponsorship)
-:::
-
-::: div addon-example
-![](/@/assets/images/sponsorships/website-agenda-ads_dark.webp)
-Agenda Page Ads
-:::
-
-<style scoped>
-.addon-example {
-  display: inline-block;
-  width: 50%;
-  text-align: center;
-  padding: 5px;
-}
-</style>
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/website-agenda-ads_dark.webp">
+  Agenda Page Ads
+</div>
 
 Deadline for sponsorship: **July 11, 2025**
 
@@ -106,16 +96,10 @@ COSCUP (Conference for Open Source Coders, Users and Promoters)
 
 To see our past conference photos, please visit : [COSCUP flickr album](https://www.flickr.com/photos/coscup/albums).
 
-::: div attendee
-![](/@/assets/images/sponsorships/coscup-attendee.webp)
-96.2% of attendees would recommend others to join COSCUP
-:::
-
-<style scoped>
-.attendee {
-  text-align: center;
-}
-</style>
+<div class="attendee">
+  <img src="/@/assets/images/sponsorships/coscup-attendee.webp">
+  96.2% of attendees would recommend others to join COSCUP
+</div>
 
 ## We wish all the sponsors in COSCUP x RubyConf Taiwan 2025 Taiwan 2025 would
 
@@ -126,3 +110,16 @@ To see our past conference photos, please visit : [COSCUP flickr album](https://
 - Network with professionals.
 
 Contact us: [sponsorship@coscup.org](mailto:sponsorship@coscup.org)
+
+<style scoped>
+.addon-example {
+  display: inline-block;
+  width: 50%;
+  text-align: center;
+  padding: 5px;
+}
+
+.attendee {
+  text-align: center;
+}
+</style>

--- a/content/zh_tw/sponsorship/index.md
+++ b/content/zh_tw/sponsorship/index.md
@@ -27,35 +27,25 @@ COSCUP 2024 會眾問卷回饋：
 
 <AddonTable />
 
-::: div addon-example
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/flag_dark.webp">
+  Keynote 演講廳 垂吊布條
+</div>
 
-![](/@/assets/images/sponsorships/flag_dark.webp)
-Keynote 演講廳 垂吊布條
-:::
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/promotion_dark.webp">
+  大會點心區桌旗（兩天）
+</div>
 
-::: div addon-example
-![](/@/assets/images/sponsorships/promotion_dark.webp)
-大會點心區桌旗（兩天）
-:::
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/lanyards_dark.webp">
+  頸帶獨家贊助
+</div>
 
-::: div addon-example
-![](/@/assets/images/sponsorships/lanyards_dark.webp)
-頸帶獨家贊助
-:::
-
-::: div addon-example
-![](/@/assets/images/sponsorships/website-agenda-ads_dark.webp)
-網站議程頁面廣告
-:::
-
-<style scoped>
-.addon-example {
-  display: inline-block;
-  width: 50%;
-  text-align: center;
-  padding: 5px;
-}
-</style>
+<div class="addon-example">
+  <img src="/@/assets/images/sponsorships/website-agenda-ads_dark.webp">
+  網站議程頁面廣告
+</div>
 
 因應相關製作物所需的工作時間，贊助截止日期：**2025 年 7 月 11 日**
 
@@ -106,16 +96,10 @@ COSCUP (Conference for Open Source Coders, Users and Promoters ; 開源人年會
 
 歡迎從照片中回顧我們精彩的時刻: [COSCUP flickr album](https://www.flickr.com/photos/coscup/albums)。
 
-::: div attendee
-![](/@/assets/images/sponsorships/coscup-attendee.webp)
-96.2% 與會者願意推薦其他人參加往後的 COSCUP
-:::
-
-<style scoped>
-.attendee {
-  text-align: center;
-}
-</style>
+<div class="attendee">
+  <img src="/@/assets/images/sponsorships/coscup-attendee.webp">
+  96.2% 與會者願意推薦其他人參加往後的 COSCUP
+</div>
 
 ## 我們期待所有的贊助單位在 COSCUP x RubyConf Taiwan 2025 都可以...
 
@@ -126,3 +110,16 @@ COSCUP (Conference for Open Source Coders, Users and Promoters ; 開源人年會
 - 與專業人士交流。
 
 聯絡我們： [sponsorship@coscup.org](mailto:sponsorship@coscup.org)
+
+<style scoped>
+.addon-example {
+  display: inline-block;
+  width: 50%;
+  text-align: center;
+  padding: 5px;
+}
+
+.attendee {
+  text-align: center;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "@vueuse/core": "13.1.0",
     "calendar-link": "2.8.0",
     "leaflet": "1.9.4",
-    "markdown-it": "14.1.0",
-    "markdown-it-container": "4.0.0",
     "osmtogeojson": "3.0.0-beta.5",
     "swiper": "11.2.6",
     "unplugin-icons": "22.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,6 @@ importers:
       leaflet:
         specifier: 1.9.4
         version: 1.9.4
-      markdown-it:
-        specifier: 14.1.0
-        version: 14.1.0
-      markdown-it-container:
-        specifier: 4.0.0
-        version: 4.0.0
       osmtogeojson:
         specifier: 3.0.0-beta.5
         version: 3.0.0-beta.5
@@ -1869,9 +1863,6 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
-
   lint-staged@15.5.1:
     resolution: {integrity: sha512-6m7u8mue4Xn6wK6gZvSCQwBvMBR36xfY24nF5bMTf2MHDYG6S3yhJuOgdYVw99hsjyDt2d4z168b3naI8+NWtQ==}
     engines: {node: '>=18.12.0'}
@@ -1914,13 +1905,6 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
-  markdown-it-container@4.0.0:
-    resolution: {integrity: sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==}
-
-  markdown-it@14.1.0:
-    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
-    hasBin: true
-
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -1959,9 +1943,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2273,10 +2254,6 @@ packages:
   protocol-buffers-schema@3.6.0:
     resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
 
-  punycode.js@2.3.1:
-    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
-    engines: {node: '>=6'}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2577,9 +2554,6 @@ packages:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uc.micro@2.1.0:
-    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -4667,10 +4641,6 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
-  linkify-it@5.0.0:
-    dependencies:
-      uc.micro: 2.1.0
-
   lint-staged@15.5.1:
     dependencies:
       chalk: 5.4.1
@@ -4728,17 +4698,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   mark.js@8.11.1: {}
-
-  markdown-it-container@4.0.0: {}
-
-  markdown-it@14.1.0:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.0
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -4855,8 +4814,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-
-  mdurl@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -5261,8 +5218,6 @@ snapshots:
 
   protocol-buffers-schema@3.6.0: {}
 
-  punycode.js@2.3.1: {}
-
   punycode@2.3.1: {}
 
   quansync@0.2.10: {}
@@ -5562,8 +5517,6 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@5.8.3: {}
-
-  uc.micro@2.1.0: {}
 
   ufo@1.5.4: {}
 


### PR DESCRIPTION
在 #1 中我們新增了 `markdown-it-container` 套件，並設定了 `::: div` 語法。考量原生 HTML 並沒有過於冗長且可讀性更高，我覺得我們可以保持專案簡單，減少設定和對套件的依賴。

順帶一提，`markdown-it-container` 有 [DefinitelyTyped](https://www.npmjs.com/package/@types/markdown-it-container) 提供的型別定義。