### PR TITLE
fix: use official GitHub Pages actions for page deployment

### DIFF
--- a/.github/workflows/deploy-to-pages.yaml
+++ b/.github/workflows/deploy-to-pages.yaml
@@ -7,7 +7,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -36,20 +36,24 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
-
-      - name: Run ESLint
-        run: pnpm lint
-
-      - name: Check types
-        run: pnpm type-check
+        run: pnpm install --prod --ignore-scripts
 
       - name: Build with VitePress
         run: pnpm build
 
-      - name: Deploy 📡
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .vitepress/dist
-          force_orphan: true
+          path: .vitepress/dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
This PR replaces [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) with the official actions from GitHub ([actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact) and [actions/deploy-pages](https://github.com/actions/deploy-pages)). We'll need to change the deployment source to GitHub Actions.

![](https://github.com/user-attachments/assets/2b0b16f2-4443-4b39-81c3-429de3b04189)
