### PR TITLE
Center the banner when the screen is wider than 1920 pixels

### DIFF
--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -29,4 +29,11 @@ import banner from '#assets/images/banner.png'
     display: none;
   }
 }
+
+@media screen and (min-width: 1920px) {
+  .banner {
+    width: 1920px;
+    margin: 0 auto;
+  }
+}
 </style>


### PR DESCRIPTION
This fixes the issue about the look of the banner when the screen width exceeds 1920 pixels.

Before:

![Screenshot 2025-05-10 at 18-03-53 COSCUP x RubyConf Taiwan 2025](https://github.com/user-attachments/assets/4a829f7e-9ed8-4d03-b40c-83c14a41b93f)

After with this fix:

![Screenshot 2025-05-10 at 18-04-57 COSCUP x RubyConf Taiwan 2025](https://github.com/user-attachments/assets/5b1e6ee5-0b02-41d3-862b-a5181342940c)
