### PR TITLE
feat: add getGoogleSheet utility function for data loaders

### DIFF
--- a/loaders/utils.ts
+++ b/loaders/utils.ts
@@ -24,6 +24,11 @@ export async function getGoogleSheet<SheetRow extends Record<string, string>>({
 }): Promise<SheetRow[]> {
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${sheetName}?key=${apiKey}`
   const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Google Sheet: ${response.status} ${response.statusText}`)
+  }
+
   const data: GoogleSheetResponse = await response.json()
 
   if (!data.values) throw new Error(`No data found in the ${sheetName} sheet`)

--- a/loaders/utils.ts
+++ b/loaders/utils.ts
@@ -1,0 +1,42 @@
+interface GoogleSheetResponse {
+  majorDimension: string
+  range: string
+  values: string[][]
+}
+
+/**
+ * Fetch a sheet from a Google Sheet and return the data as an array of objects.
+ * @param options Options for fetching a Google Sheet.
+ * @param options.sheetId The ID of the Google Sheet.
+ * @param options.sheetName The name of the sheet within the Google Sheet.
+ * @param options.apiKey The API key for accessing the Google Sheets API.
+ * @template SheetRow The type of the objects in the returned array.
+ * @returns A promise that resolves to an array of objects representing the data in the sheet.
+ */
+export async function getGoogleSheet<SheetRow extends Record<string, string>>({
+  sheetId,
+  sheetName,
+  apiKey,
+}: {
+  sheetId: string
+  sheetName: string
+  apiKey: string
+}): Promise<SheetRow[]> {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${sheetName}?key=${apiKey}`
+  const response = await fetch(url)
+  const data: GoogleSheetResponse = await response.json()
+
+  if (!data.values) throw new Error(`No data found in the ${sheetName} sheet`)
+
+  // First row is the header, subsequent rows are the data
+  const [headers, ...values] = data.values
+
+  const result = values.map((row) =>
+    headers.reduce((obj, key, i) => {
+      obj[key] = row[i] || ''
+      return obj
+    }, {} as Record<string, string>),
+  ) as SheetRow[]
+
+  return result
+}


### PR DESCRIPTION
因為我發現有許多 data loader 都需要從 Google Sheets 取得資料，所以我新增了一個取得並轉換 Google sheet 的函數，讓各 data loader 不需要寫重複的邏輯。

可以應用在 #16、#43 和 #54。