### PR TITLE
fix(deps): remove unused marked package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "leaflet": "1.9.4",
     "markdown-it": "14.1.0",
     "markdown-it-container": "4.0.0",
-    "marked": "15.0.12",
     "osmtogeojson": "3.0.0-beta.5",
     "reka-ui": "2.3.2",
     "swiper": "11.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       markdown-it-container:
         specifier: 4.0.0
         version: 4.0.0
-      marked:
-        specifier: 15.0.12
-        version: 15.0.12
       osmtogeojson:
         specifier: 3.0.0-beta.5
         version: 3.0.0-beta.5
@@ -2131,11 +2128,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
-    hasBin: true
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -5208,8 +5200,6 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
-
-  marked@15.0.12: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:


### PR DESCRIPTION
a90fe1366b4c3386d06a9566714ebe4f29af661b removed all of the usages of `marked` but it's still listed as an dependency. This PR removes the dependency.