### PR TITLE
fix(sponsors): shorten English sponsor badge text for better layout

### DIFF
--- a/components/SponsorFooter.vue
+++ b/components/SponsorFooter.vue
@@ -21,15 +21,15 @@ const getSponsorTimesText = computed(() => (sponsor: Sponsor) => {
   if (sponsor.type === '3') {
     return isZhTw
       ? `累計 ${sponsor.times} 年合作`
-      : `Collaborated a total of ${sponsor.times} years`
+      : `${sponsor.times}-yr collaborator`
   } else if (sponsor.type === '2') {
     return isZhTw
       ? `累計 ${sponsor.times} 年贊助`
-      : `Sponsored a total of ${sponsor.times} years`
+      : `${sponsor.times}-yr sponsor`
   } else if (sponsor.type === '1') {
     return isZhTw
       ? `連續 ${sponsor.times} 年贊助`
-      : `Sponsored ${sponsor.times} consecutive years`
+      : `${sponsor.times}-yr consecutive sponsor`
   }
   return ''
 })

--- a/content/en/sponsor/SponsorCard.vue
+++ b/content/en/sponsor/SponsorCard.vue
@@ -38,15 +38,15 @@ defineProps<{ sponsor: Sponsor }>()
     <span
       v-if="sponsor.type === '3'"
       class="badge"
-    >Collaborated for a total of {{ sponsor.times }} years</span>
+    >{{ sponsor.times }}-yr collaborator</span>
     <span
       v-else-if="sponsor.type === '2'"
       class="badge"
-    >Sponsored for a total of {{ sponsor.times }} years</span>
+    >{{ sponsor.times }}-yr sponsor</span>
     <span
       v-else-if="sponsor.type === '1'"
       class="badge consecutive"
-    >Sponsored for {{ sponsor.times }} consecutive years</span>
+    >{{ sponsor.times }}-yr consecutive sponsor</span>
   </div>
 </template>
 


### PR DESCRIPTION
This PR shortens the English sponsor badge text to improve layout and readability across sponsor cards and footer components.

Fixes #133.

## Text Changes

| Type | Before | After |
|------|--------|-------|
| Collaborator | "Collaborated a total of X years" | "X-yr collaborator" |
| Sponsor | "Sponsored a total of X years" | "X-yr sponsor" |
| Consecutive | "Sponsored X consecutive years" | "X-yr consecutive sponsor" |
