### PR TITLE
feat(sessions): add search functionality to sessions schedule

### DIFF
--- a/components/Session/SessionDateTab.vue
+++ b/components/Session/SessionDateTab.vue
@@ -53,7 +53,7 @@ const formattedEndDate = computed(() => formatConferenceDate(props.endDate))
   height: var(--date-tab-height);
 
   &.mobile {
-    margin-block: 8px 12px;
+    padding-block: 8px 0;
   }
 }
 

--- a/components/Session/SessionsSchedule.vue
+++ b/components/Session/SessionsSchedule.vue
@@ -320,6 +320,16 @@ onMounted(() => {
             :items="viewMenuItems"
           />
         </div>
+
+        <div
+          v-if="!isDesktop"
+          class="toolbar-secondary"
+        >
+          <CTextField
+            v-model="searchQuery"
+            :placeholder="messages.searchSessions || 'Search sessions…'"
+          />
+        </div>
       </div>
 
       <!-- Schedule Container -->
@@ -438,7 +448,7 @@ onMounted(() => {
   height: calc(100vh - var(--vp-nav-height));
 
   @media (width <= 40rem /* sm */) {
-    --controls-height: 3rem;
+    --controls-height: 84px;
     padding: 0 8px 8px;
   }
 
@@ -456,7 +466,9 @@ onMounted(() => {
   height: var(--controls-height);
 
   @media (width <= 40rem /* sm */) {
-    padding: 0;
+    padding: 4px 0;
+    gap: 4px;
+    flex-wrap: wrap;
   }
 
   > .toolbar-start {
@@ -469,6 +481,10 @@ onMounted(() => {
     display: flex;
     align-items: center;
     gap: 8px;
+  }
+
+  > .toolbar-secondary {
+    width: 100%;
   }
 }
 

--- a/components/Session/SessionsSchedule.vue
+++ b/components/Session/SessionsSchedule.vue
@@ -120,6 +120,8 @@ function handleTagsToggle(id: string, checked: boolean) {
   }
 }
 
+const searchQuery = useSessionStorage('search-query', '')
+
 // View state
 const selectedView = useLocalStorage<'conference' | 'bookmarked'>('selected-view', 'conference', {
   serializer: {
@@ -189,6 +191,17 @@ const displaySessions = computed(() => {
     if (selectedTags.value.size > 0) {
       const hasMatchingTag = selectedTags.value.has(`language:${session.language}`) || selectedTags.value.has(`difficulty:${session.difficulty}`)
       if (!hasMatchingTag) {
+        return false
+      }
+    }
+
+    if (searchQuery.value) {
+      const searchLower = searchQuery.value.toLowerCase()
+      if (
+        !session.title.toLowerCase().includes(searchLower) &&
+        !session.room?.name.toLowerCase().includes(searchLower) &&
+        !session.speakers?.some((speaker) => speaker.name.toLowerCase().includes(searchLower))
+      ) {
         return false
       }
     }
@@ -294,11 +307,10 @@ onMounted(() => {
             @toggle="handleTagsToggle"
           />
 
-          <!--
-        <CIconButton variant="basic">
-          <IconPhMagnifyingGlass />
-        </CIconButton>
-        -->
+          <CTextField
+            v-model="searchQuery"
+            :placeholder="messages.searchSessions || 'Search sessions…'"
+          />
         </div>
 
         <div class="toolbar-end">

--- a/components/Session/SessionsSchedule.vue
+++ b/components/Session/SessionsSchedule.vue
@@ -436,10 +436,13 @@ onMounted(() => {
   min-width: 100%;
   padding: 18px 32px;
   height: calc(100vh - var(--vp-nav-height));
-}
 
-@media (min-width: 1024px) {
-  .schedule-page {
+  @media (width <= 40rem /* sm */) {
+    --controls-height: 3rem;
+    padding: 0 8px 8px;
+  }
+
+  @media (width <= 1024px) {
     --column-time-header: 68px;
     --column-width: 320px;
   }
@@ -451,6 +454,10 @@ onMounted(() => {
   align-items: center;
   padding: 16px 0;
   height: var(--controls-height);
+
+  @media (width <= 40rem /* sm */) {
+    padding: 0;
+  }
 
   > .toolbar-start {
     display: flex;

--- a/components/Session/SessionsSchedule.vue
+++ b/components/Session/SessionsSchedule.vue
@@ -445,7 +445,7 @@ onMounted(() => {
   width: 100%;
   min-width: 100%;
   padding: 18px 32px;
-  height: calc(100vh - var(--vp-nav-height));
+  height: calc(100dvh - var(--vp-nav-height));
 
   @media (width <= 40rem /* sm */) {
     --controls-height: 84px;

--- a/components/Session/SessionsSchedule.vue
+++ b/components/Session/SessionsSchedule.vue
@@ -308,6 +308,7 @@ onMounted(() => {
           />
 
           <CTextField
+            v-if="isDesktop"
             v-model="searchQuery"
             :placeholder="messages.searchSessions || 'Search sessions…'"
           />

--- a/components/Session/session-messages.ts
+++ b/components/Session/session-messages.ts
@@ -1,5 +1,5 @@
 export type MessageKey =
-  'time' | 'speaker' | 'room' | 'collaborativeNotes' | 'track' | 'abstract' | 'aboutSpeaker' | 'advertisement' | 'unknown' | 'community' | 'tags' | 'conference' | 'bookmarked' | 'mainTrack' | 'searchCommunity' | 'searchTags' | 'noSessions'
+  'time' | 'speaker' | 'room' | 'collaborativeNotes' | 'track' | 'abstract' | 'aboutSpeaker' | 'advertisement' | 'unknown' | 'community' | 'tags' | 'conference' | 'bookmarked' | 'mainTrack' | 'searchCommunity' | 'searchTags' | 'noSessions' | 'searchSessions'
 
 export const enMessages: Record<MessageKey, string> = {
   time: 'Time',
@@ -19,6 +19,7 @@ export const enMessages: Record<MessageKey, string> = {
   searchCommunity: 'Search community…',
   searchTags: 'Search tags…',
   noSessions: 'No sessions',
+  searchSessions: 'Search sessions…',
 }
 
 export const zhTwMessages: Record<MessageKey, string> = {
@@ -39,4 +40,5 @@ export const zhTwMessages: Record<MessageKey, string> = {
   searchCommunity: '搜尋社群……',
   searchTags: '搜尋標籤……',
   noSessions: '沒有議程',
+  searchSessions: '搜尋議程……',
 }


### PR DESCRIPTION
- Add search input field that filters sessions by title, room, and speaker name
- Show search bar on desktop in main toolbar, on mobile in secondary toolbar row  
- Persist search query in session storage
- Improve mobile responsive layout with proper toolbar wrapping and spacing
- Add search placeholder text with i18n support for both English and Traditional Chinese