### PR TITLE
feat/fix: Make sponsor vertical area sticky and enhanced close button experience

### DIFF
--- a/components/Session/SessionModal.vue
+++ b/components/Session/SessionModal.vue
@@ -56,6 +56,15 @@ const sessionTime = computed(() => {
             >
               <IconPhX style="color: var(--color-gray-500);" />
             </button>
+            <button
+              class="dialog-close-mobile"
+              @click="$emit('close')"
+            >
+              <IconPhX style="color: var(--color-white); font-size: var(--text-lg);" />
+              <span class="dialog-close-mobile-text">
+                {{ messages.close }}
+              </span>
+            </button>
           </div>
           <div class="main-content">
             <h1
@@ -276,6 +285,10 @@ const sessionTime = computed(() => {
   margin: 0;
 }
 
+.dialog-close-mobile {
+  display: none;
+}
+
 @media (min-width: 500px) {
   .dialog {
     width: clamp(500px, 75vw, 800px);
@@ -310,21 +323,21 @@ const sessionTime = computed(() => {
 }
 
 .dialog-close {
-  position: static;
+  position: absolute;
   right: auto;
   top: auto;
+  border: 1px solid var(--color-gray-300);
   border-radius: 0.25rem;
-  opacity: 0.7;
+  opacity: 1;
   transition: opacity 0.2s;
   outline: none;
-  background: none;
-  border: none;
   box-shadow: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem;
+  padding: 0.65rem;
+  backdrop-filter: blur(10px);
 }
 
 .dialog-close:hover {
@@ -338,6 +351,47 @@ const sessionTime = computed(() => {
 
 .dialog-close:disabled {
   pointer-events: none;
+}
+
+@media (max-width: 500px) {
+  .dialog-close {
+    display: none;
+  }
+
+  .dialog-close-mobile {
+    position: absolute;
+    bottom: 1rem;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--background, var(--color-primary-400));
+    gap: 0.25rem;
+    border: none;
+    border-radius: 0.25rem;
+    opacity: 1;
+    transition: opacity 0.2s;
+    outline: none;
+    box-shadow: 0 0 10px 1px var(--color-gray-400);
+    padding: 0.4rem;
+    margin: 0 1.5rem;
+    transition: all 0.2s;
+  }
+
+  .dialog-close-mobile:active {
+    scale: 0.95;
+  }
+
+  .dialog-close-mobile:disabled {
+    pointer-events: none;
+  }
+
+  .dialog-close-mobile-text {
+    font-size: var(--text-lg);
+    font-weight: 400;
+    color: var(--color-white);
+  }
 }
 
 @media (min-width: 900px) {

--- a/components/Session/SessionModal.vue
+++ b/components/Session/SessionModal.vue
@@ -4,7 +4,7 @@ import type { MessageKey } from './session-messages'
 import CTag from '#components/CTag.vue'
 import { formatTimeRange } from '#utils/format-time.ts'
 import { markdownToHtml } from '#utils/markdown.ts'
-import { computedAsync } from '@vueuse/core'
+import { breakpointsTailwind, computedAsync, useBreakpoints } from '@vueuse/core'
 import { computed } from 'vue'
 
 const props = defineProps<{
@@ -15,6 +15,10 @@ const props = defineProps<{
 defineEmits<{
   (e: 'close'): void
 }>()
+
+// Reactive state for mobile view
+const breakpoints = useBreakpoints(breakpointsTailwind)
+const isDesktop = breakpoints.greater('sm')
 
 const advertisement = computedAsync(async () => {
   const { getAdvertisement } = await import('./advertisement')
@@ -50,21 +54,25 @@ const sessionTime = computed(() => {
         <main class="content-col">
           <div class="dialog-header">
             <div class="header-spacer" />
-            <button
+            <CButton
+              v-if="isDesktop"
               class="dialog-close"
+              variant="secondary"
               @click="$emit('close')"
             >
-              <IconPhX style="color: var(--color-gray-500);" />
-            </button>
-            <button
+              <IconPhX />
+            </CButton>
+            <CButton
+              v-else
               class="dialog-close-mobile"
+              variant="primary"
               @click="$emit('close')"
             >
-              <IconPhX style="color: var(--color-white); font-size: var(--text-lg);" />
-              <span class="dialog-close-mobile-text">
-                {{ messages.close }}
-              </span>
-            </button>
+              <template #icon>
+                <IconPhX />
+              </template>
+              {{ messages.close }}
+            </CButton>
           </div>
           <div class="main-content">
             <h1
@@ -269,7 +277,6 @@ const sessionTime = computed(() => {
   box-shadow:
     0 10px 15px -3px rgba(0, 0, 0, 0.1),
     0 4px 6px -4px rgba(0, 0, 0, 0.1);
-  transition: all 0.5s ease-in-out;
   top: 0;
   bottom: 0;
   right: 0;
@@ -281,10 +288,6 @@ const sessionTime = computed(() => {
   overflow-y: auto;
   padding: 0;
   margin: 0;
-}
-
-.dialog-close-mobile {
-  display: none;
 }
 
 @media (min-width: 500px) {
@@ -324,72 +327,12 @@ const sessionTime = computed(() => {
   position: absolute;
   right: auto;
   top: auto;
-  border: 1px solid var(--color-gray-300);
-  border-radius: 0.25rem;
-  opacity: 1;
-  transition: opacity 0.2s;
-  outline: none;
-  box-shadow: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.65rem;
-  backdrop-filter: blur(10px);
 }
 
-.dialog-close:hover {
-  opacity: 1;
-}
-
-.dialog-close:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--ring-color, #3b82f6);
-}
-
-.dialog-close:disabled {
-  pointer-events: none;
-}
-
-@media (max-width: 500px) {
-  .dialog-close {
-    display: none;
-  }
-
-  .dialog-close-mobile {
-    position: absolute;
-    bottom: 1rem;
-    left: 0;
-    right: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--background, var(--color-primary-400));
-    gap: 0.25rem;
-    border: none;
-    border-radius: 0.25rem;
-    opacity: 1;
-    transition: opacity 0.2s;
-    outline: none;
-    box-shadow: 0 0 10px 1px var(--color-gray-400);
-    padding: 0.4rem;
-    margin: 0 1.5rem;
-    transition: all 0.2s;
-  }
-
-  .dialog-close-mobile:active {
-    scale: 0.95;
-  }
-
-  .dialog-close-mobile:disabled {
-    pointer-events: none;
-  }
-
-  .dialog-close-mobile-text {
-    font-size: var(--text-lg);
-    font-weight: 400;
-    color: var(--color-white);
-  }
+.dialog-close-mobile {
+  position: absolute;
+  bottom: 1rem;
+  width: 90% !important;
 }
 
 @media (min-width: 900px) {

--- a/components/Session/SessionModal.vue
+++ b/components/Session/SessionModal.vue
@@ -287,6 +287,7 @@ const sessionTime = computed(() => {
   flex-direction: column;
   flex: 1 1 0%;
   min-width: 0;
+  overflow-y: auto;
 }
 
 .dialog-header {

--- a/components/Session/SessionModal.vue
+++ b/components/Session/SessionModal.vue
@@ -377,12 +377,6 @@ const sessionTime = computed(() => {
     transition: all 0.2s;
   }
 
-  @supports (-webkit-touch-callout: none) {
-    .dialog-close-mobile {
-      bottom: 1rem;
-    }
-  }
-
   .dialog-close-mobile:active {
     scale: 0.95;
   }

--- a/components/Session/SessionModal.vue
+++ b/components/Session/SessionModal.vue
@@ -262,7 +262,8 @@ const sessionTime = computed(() => {
 
 .dialog-content {
   display: flex;
-  height: 100%;
+  position: relative;
+  height: 100dvh;
   width: 100%;
   background: var(--background, #fff);
   box-shadow:
@@ -272,10 +273,7 @@ const sessionTime = computed(() => {
   top: 0;
   bottom: 0;
   right: 0;
-  height: 100%;
-  width: 100%;
   max-width: 100%;
-  max-height: 100%;
   border: none;
   border-left: 1px solid #e5e7eb;
   animation-duration: 0.5s;
@@ -377,6 +375,12 @@ const sessionTime = computed(() => {
     padding: 0.4rem;
     margin: 0 1.5rem;
     transition: all 0.2s;
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    .dialog-close-mobile {
+      bottom: 1rem;
+    }
   }
 
   .dialog-close-mobile:active {

--- a/components/Session/session-messages.ts
+++ b/components/Session/session-messages.ts
@@ -22,7 +22,8 @@ export type MessageKey =
   'bookmarkedSessionsRestoredButton' |
   'bookmarkedSessionsCopied' |
   'bookmarkedSessionsCopiedDescription' |
-  'bookmarkedSessionsCopiedFailed'
+  'bookmarkedSessionsCopiedFailed' |
+  'close'
 
 export const enMessages: Record<MessageKey, string> = {
   time: 'Time',
@@ -49,6 +50,7 @@ export const enMessages: Record<MessageKey, string> = {
   bookmarkedSessionsCopied: 'Successfully copied the share URL to your clipboard',
   bookmarkedSessionsCopiedDescription: 'This URL points to your current bookmarked sessions. Other users can use this URL to restore the same bookmarked sessions.',
   bookmarkedSessionsCopiedFailed: 'Failed to copy the share URL to your clipboard',
+  close: 'Close',
 }
 
 export const zhTwMessages: Record<MessageKey, string> = {
@@ -76,4 +78,5 @@ export const zhTwMessages: Record<MessageKey, string> = {
   bookmarkedSessionsCopied: '已將收藏的議程連結複製至剪貼簿',
   bookmarkedSessionsCopiedDescription: '這個連結指向您目前的收藏議程。其他使用者可以使用此連結還原相同的收藏議程。',
   bookmarkedSessionsCopiedFailed: '無法將收藏的議程分享至剪貼簿',
+  close: '關閉',
 }


### PR DESCRIPTION
This pull requests has the features and fixes added as listed below:
- fix: Now vertical sponsor area is sticky at the right hand side, and it won't be move if user scrolled the content
   <img src="https://github.com/user-attachments/assets/9277a51e-6e0f-48bc-8adf-9f3c7fb0c19e" width=500 />

- chore: Now close button experience has been enhanced
    - Desktop: Close button now has blur background, and it's sticky on the right upper side of content
       <img width="294" height="234" alt="CleanShot 2025-08-10 at 09 49 46@2x" src="https://github.com/user-attachments/assets/87927dfb-d5ed-415b-9c75-908f57a1d2cb" />

    - Mobile: Close button now its own new design
       <img width="300" height="1510" alt="CleanShot 2025-08-10 at 09 49 57@2x" src="https://github.com/user-attachments/assets/33dc3f3a-0b5d-493b-931c-3558ed98d219" />

