### PR TITLE
ci: pass VITE_FRINGE_SHEET_NAME to the code-quality workflow

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,6 +18,7 @@ jobs:
       VITE_SPONSOR_LEVELS_SHEET_NAME: ${{ secrets.VITE_SPONSOR_LEVELS_SHEET_NAME }}
       VITE_SPONSOR_NEWS_SHEET_NAME: ${{ secrets.VITE_SPONSOR_NEWS_SHEET_NAME }}
       VITE_SPONSOR_SHEET_NAME: ${{ secrets.VITE_SPONSOR_SHEET_NAME }}
+      VITE_FRINGE_SHEET_NAME: ${{ secrets.VITE_FRINGE_SHEET_NAME }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
`loaders/fringe.data.ts` reads `env.VITE_FRINGE_SHEET_NAME`, but only `deploy-to-pages.yaml` exports it — `code-quality.yaml` doesn't. On PR builds the URL becomes `…/values/undefined?key=…`, Sheets returns 400, and every CI log carries `Error fetching fringes: No data found in the spreadsheet`. Non-fatal (loader catches and returns \`[]\`), but it leaves PR previews with an empty Fringe section.

The repo secret already exists (created 2025-08-02); this one line wires it through.

## Test plan

- [ ] CI green
- [ ] Fringe section on the preview renders all 9 rows